### PR TITLE
Fix io returned by encode_io doesnt emit EOFError when readpartial

### DIFF
--- a/lib/discordrb/voice/encoder.rb
+++ b/lib/discordrb/voice/encoder.rb
@@ -87,10 +87,8 @@ module Discordrb::Voice
     # @param options [String] ffmpeg options to pass after the -i flag
     # @return [IO] the audio, encoded as s16le PCM
     def encode_io(io, options = '')
-      ret_io, writer = IO.pipe
       command = "#{ffmpeg_command} -loglevel 0 -i - #{options} -f s16le -ar 48000 -ac 2 #{filter_volume_argument} pipe:1"
-      spawn(command, in: io, out: writer)
-      ret_io
+      IO.popen(command, in: io)
     end
 
     private


### PR DESCRIPTION
# Summary

If you apply the io object from #play_io to the encoder and send it to #play, #readpartial will block without emitting EOFError when the audio ends.
#### e.g.
`voice_bot.play_io(File.open('example/data/music.mp3', 'r'))`
`require 'open-uri'; voice_bot.play_io(open(VOICE_DATA_URL))`


This was fixed by passing the return value of IO.popen instead of using IO.pipe. And I think this is more natural code


## Changed

lib/discordrb/voice/encoder.rb#L90-93: IO.pipe => IO.popen

