### PR TITLE
Add missing params to send_temporary_message

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -382,11 +382,12 @@ module Discordrb
     # @param timeout [Float] The amount of time in seconds after which the message sent will be deleted.
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
-    def send_temporary_message(channel, content, timeout, tts = false, embed = nil)
+    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
+    def send_temporary_message(channel, content, timeout, tts = false, embed = nil, attachments = nil)
       Thread.new do
         Thread.current[:discordrb_name] = "#{@current_thread}-temp-msg"
 
-        message = send_message(channel, content, tts, embed)
+        message = send_message(channel, content, tts, embed, attachments)
         sleep(timeout)
         message.delete
       end

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -35,8 +35,11 @@ module Discordrb::Events
     # Sends a temporary message to the channel this message was sent in, right now.
     # @param content [String] The content to send. Should not be longer than 2000 characters or it will result in an error.
     # @param timeout [Float] The amount of time in seconds after which the message sent will be deleted.
-    def send_temporary_message(content, timeout)
-      channel.send_temporary_message(content, timeout)
+    # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
+    # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
+    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
+    def send_temporary_message(content, timeout, tts = false, embed = nil, attachments = nil)
+      channel.send_temporary_message(content, timeout, tts, embed, attachments)
     end
 
     # Adds a string to be sent after the event has finished execution. Avoids problems with rate limiting because only


### PR DESCRIPTION
Added `attachments` param to where it was missing. Without it `event.send_temp` returns `wrong number of arguments (given 6, expected 3..5)`.